### PR TITLE
use streams to append data to files

### DIFF
--- a/src/Http/Controllers/TusUploadController.php
+++ b/src/Http/Controllers/TusUploadController.php
@@ -28,7 +28,7 @@ class TusUploadController extends BaseController
             rawMetadata: $request->header('upload-metadata')
         );
 
-        $contents = Tus::extensionIsActive('creation-with-upload') && (int) $request->header('content-length') > 0 ? $request->getContent() : '';
+        $contents = Tus::extensionIsActive('creation-with-upload') && (int) $request->header('content-length') > 0 ? $request->getContent(true) : '';
 
         Tus::storage()->put(
             path: $tusFile->path,
@@ -83,7 +83,7 @@ class TusUploadController extends BaseController
             event(new FileUploadStarted($tusFile));
         }
 
-        $offset = Tus::storage()->size($tusFile->path) + Tus::append($tusFile->path, $request->getContent());
+        $offset = Tus::storage()->size($tusFile->path) + Tus::append($tusFile->path, $request->getContent(true));
 
         if ($offset === (int) Tus::metadata()->readMeta($id, 'size')) {
             event(new FileUploadFinished($tusFile));

--- a/src/Tus.php
+++ b/src/Tus.php
@@ -41,6 +41,9 @@ class Tus
 
     public function isUploadExpired(int $lastModified): bool
     {
+        if ((int) config('tus.upload_expiration') < 1) {
+            return false;
+        }
         return Date::createFromTimestamp($lastModified)->addMinutes((int) config('tus.upload_expiration'))->isPast();
     }
 

--- a/src/Tus.php
+++ b/src/Tus.php
@@ -41,9 +41,10 @@ class Tus
 
     public function isUploadExpired(int $lastModified): bool
     {
-        if ((int) config('tus.upload_expiration') < 1) {
+        if ((int) config('tus.upload_expiration') === 0) {
             return false;
         }
+
         return Date::createFromTimestamp($lastModified)->addMinutes((int) config('tus.upload_expiration'))->isPast();
     }
 

--- a/src/Tus.php
+++ b/src/Tus.php
@@ -105,7 +105,7 @@ class Tus
         return Storage::disk(config('tus.storage_disk'));
     }
 
-    public function append(string $path, string $data): int
+    public function append(string $path, $data): int
     {
         $path = $this->storage()->path($path);
 
@@ -119,7 +119,7 @@ class Tus
             throw new FileAppendException(message: 'File open error');
         }
 
-        $fw = fwrite($fp, $data);
+        $fw = stream_copy_to_stream($data, $fp);
 
         if ($fw === false) {
             throw new FileAppendException(message: 'File write error');


### PR DESCRIPTION
Using this package on a project that handles huge file uploads, I was reaching memory limit when uploading.
This PR allows to use streams instead of strings to write data. 

This PR also fixes the following issue : If you set an expiration date to null, the files are automatically deleted by the controller (patch method) as the file is considered old. The method `KalynaSolutions\Tus\Tus::isUploadExpired` does not check that the expiration date is null